### PR TITLE
added startup-config provisioning via a temp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a k8s controller for running and managing SR Linux nodes launched from [
 
 ## Install
 
-To install the latest version of this controller on a cluster referenced in `~/.kube/config` issue the following command:
+To install the latest version of this controller on a cluster referenced in `~/.kube/config`, issue the following command:
 
 ```bash
 # latest version
@@ -54,7 +54,7 @@ kubectl delete -k https://github.com/srl-labs/srl-controller/config/default
 
 To run this controller in a test cluster deployed with [`kne`](https://github.com/openconfig/kne) and [`kind`](https://kind.sigs.k8s.io/) follow the steps outlined in the [KNE repository](https://github.com/openconfig/kne/tree/main/docs).
 
-Once the kne+kind cluster is created, a [demo topology with two SR Linux nodes](https://github.com/openconfig/kne/blob/db5fe5be01a1b6b65bd79e740e2c819c5aeb50b0/examples/srlinux/2node-srl-with-config.pbtxt) may be deployed as follows:
+Once the kne+kind cluster is created and the `srl-controller` is installed onto it, a [demo topology with two SR Linux nodes](https://github.com/openconfig/kne/blob/db5fe5be01a1b6b65bd79e740e2c819c5aeb50b0/examples/srlinux/2node-srl-with-config.pbtxt) can be deployed as follows:
 
 ```bash
 kne create examples/srlinux/2node-srl-with-config.pbtxt
@@ -73,12 +73,17 @@ To connect with SSH to the `r1` node, use `ssh admin@172.19.0.50` command.
 
 ### Loading images to kind cluster
 
-[Public SR Linux container image](https://github.com/nokia/srlinux-container-image) will be pulled by kind automatically, if Internet access is present. Images which are not available publicy can be uploaded to kind manually:
+[Public SR Linux container image](https://github.com/nokia/srlinux-container-image) will be pulled by kind automatically if Internet access is present. Images which are not available publicy can be uploaded to kind manually:
 
 ```bash
 # default kne kind cluster name is `kne`
 # which is the last argument in the command
+
+# load locally available container image
 kind load docker-image srlinux:0.0.0-38566 --name kne
+
+# load publicly available container image
+kind load docker-image ghcr.io/nokia/srlinux:22.6.4 --name kne
 ```
 
 ## Using license files
@@ -112,7 +117,7 @@ This repo contains a clientset for API access to the `Srlinux` custom resource. 
 
 ## Building `srl-controller` container image
 
-To build `srl-controller` container image execute:
+To build `srl-controller` container image, execute:
 
 ```bash
 # don't forget to set the correct tag
@@ -129,3 +134,23 @@ Finally, upload the container image to the registry:
 ```bash
 docker push ghcr.io/srl-labs/srl-controller:${tag}
 ```
+
+## Developers guide
+
+Developers should deploy the controller onto a cluster from the source code. Ensure that the `srl-controller` is [uninstalled](#uninstall) from the cluster before proceeding.
+
+Install the Srlinux CRDs onto the cluster
+
+```
+make install
+```
+
+To build and run the controller from the source code:
+
+```
+make run
+```
+
+Controller's log printed to stdout/stderr. It is possible to deploy topologies with `kne create` now.
+
+Make changes to the controller code-base, and re-run `make run` to see the changes in effect.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -17,4 +17,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: ghcr.io/srl-labs/srl-controller
-    newTag: 0.4.3
+    newTag: 0.4.4

--- a/controllers/pod.go
+++ b/controllers/pod.go
@@ -170,15 +170,16 @@ func createVolumes(s *typesv1a1.Srlinux) []corev1.Volume {
 }
 
 // handleStartupConfig creates volume mounts and volumes for srlinux pod
-// if the config file was provided in the spec.
+// if the (startup) config file was provided in the spec.
+// Volume mounts happens in the /tmp/startup-config directory and not in the /etc/opt/srlinux
+// because we need to support renaming operations on config.json, and bind mount paths are not allowing this.
+// Hence the temp location, from which the config file is then copied to /etc/opt/srlinux by the kne-entrypoint.sh
 func handleStartupConfig(s *typesv1a1.Srlinux, pod *corev1.Pod, log logr.Logger) {
 	// initialize config path and config file variables
 	cfgPath := defaultConfigPath
 	if p := s.Spec.GetConfig().ConfigPath; p != "" {
 		cfgPath = p
 	}
-
-	cfgFile := s.Spec.GetConfig().ConfigFile
 
 	// only create startup config mounts if the config data was set in kne
 	if s.Spec.Config.ConfigDataPresent {
@@ -187,7 +188,7 @@ func handleStartupConfig(s *typesv1a1.Srlinux, pod *corev1.Pod, log logr.Logger)
 			"volume.name",
 			"startup-config-volume",
 			"mount.path",
-			cfgPath+"/"+cfgFile,
+			cfgPath,
 		)
 
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
@@ -205,9 +206,8 @@ func handleStartupConfig(s *typesv1a1.Srlinux, pod *corev1.Pod, log logr.Logger)
 			pod.Spec.Containers[0].VolumeMounts,
 			corev1.VolumeMount{
 				Name:      "startup-config-volume",
-				MountPath: cfgPath + "/" + cfgFile,
-				SubPath:   cfgFile,
-				ReadOnly:  true,
+				MountPath: cfgPath,
+				ReadOnly:  false,
 			},
 		)
 	}

--- a/controllers/srlinux_controller.go
+++ b/controllers/srlinux_controller.go
@@ -42,9 +42,9 @@ const (
 	entrypointVolMntSubPath = "kne-entrypoint.sh"
 	entrypointCfgMapName    = "srlinux-kne-entrypoint"
 
-	// default path to a startup config file
+	// default path to a startup config directory
 	// the default for config file name resides within kne.
-	defaultConfigPath = "/etc/opt/srlinux"
+	defaultConfigPath = "/tmp/startup-config"
 
 	fileMode777 = 0o777
 

--- a/manifests/variants/kne-entrypoint.yml
+++ b/manifests/variants/kne-entrypoint.yml
@@ -15,4 +15,8 @@ data:
 
     sudo bash /tmp/topomac/topomac.sh
     echo "topomac.sh" script finished
+
+    # copy potentially provided startup config files
+    sudo cp -L /tmp/startup-config/* /etc/opt/srlinux/
+
     exec /entrypoint.sh "$@"


### PR DESCRIPTION
previously used method of mounting the startup-config configmap to `/etc/opt/srlinux/config.json` prevented users from using command on saving the running config to startup with `commit save` and `tools system configuration save`, as the rename operation is now allowed on read only file systems.

To workaround that, the current PR uses a temp location `/tmp/startup-config` for the original configmap, and then copies files contained within this configmap to the target dir at `kne-entrypoint.sh` stage.