### PR TITLE
relaxed regexp to parse version out of a tag

### DIFF
--- a/api/types/v1alpha1/srl_version.go
+++ b/api/types/v1alpha1/srl_version.go
@@ -29,9 +29,9 @@ func parseVersionString(s string) (*SrlVersion, error) {
 		return &SrlVersion{"0", "", "", "", ""}, nil
 	}
 
-	// https://regex101.com/r/eWS6Ms/1
+	// https://regex101.com/r/eWS6Ms/3
 	re := regexp.MustCompile(
-		`^v?(?P<major>\d{1,3})\.(?P<minor>\d{1,2})\.?(?P<patch>\d{1,2})?-?(?P<build>\d{1,10})?-?(?P<commit>\S+)?`,
+		`(?P<major>\d{1,3})\.(?P<minor>\d{1,2})\.?(?P<patch>\d{1,2})?-?(?P<build>\d{1,10})?-?(?P<commit>\S+)?`,
 	)
 
 	v := re.FindStringSubmatch(s)

--- a/api/types/v1alpha1/srl_version_test.go
+++ b/api/types/v1alpha1/srl_version_test.go
@@ -64,6 +64,11 @@ func TestParseVersionString(t *testing.T) {
 			want: &SrlVersion{"0", "0", "0", "34652", ""},
 		},
 		{
+			desc: "version_0.0.0-34652",
+			got:  "version_0.0.0-34652",
+			want: &SrlVersion{"0", "0", "0", "34652", ""},
+		},
+		{
 			desc: "latest",
 			got:  "latest",
 			want: &SrlVersion{"0", "", "", "", ""},

--- a/api/types/v1alpha1/srlinux_types_test.go
+++ b/api/types/v1alpha1/srlinux_types_test.go
@@ -95,7 +95,7 @@ func TestGetImageVersion(t *testing.T) {
 		{
 			desc: "invalid version is present",
 			spec: &SrlinuxSpec{
-				Version: "abc21.11.1",
+				Version: "abc",
 				Config:  &NodeConfig{Image: "ghcr.io/nokia/srlinux:somever"},
 			},
 			err: ErrVersionParse,
@@ -110,7 +110,7 @@ func TestGetImageVersion(t *testing.T) {
 		{
 			desc: "version is not present, invalid image tag is given",
 			spec: &SrlinuxSpec{
-				Config: &NodeConfig{Image: "ghcr.io/nokia/srlinux:21"},
+				Config: &NodeConfig{Image: "ghcr.io/nokia/srlinux:somesrl"},
 			},
 			err: ErrVersionParse,
 		},

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -17,4 +17,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: ghcr.io/srl-labs/srl-controller
-    newTag: 0.4.4
+    newTag: 0.4.5


### PR DESCRIPTION
to allow parsing custom image tags such as:

```
version_22.6.4-30192
```