### PR TITLE
Switch to `go test` instead of `ginkgo`

### DIFF
--- a/.github/workflows/linters/.golangci.yml
+++ b/.github/workflows/linters/.golangci.yml
@@ -16,7 +16,6 @@ output:
 linters:
   enable:
     - nlreturn
-    - forbidigo
     - gofumpt
     - bodyclose
     - depguard

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
-	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/openconfig/kne v0.1.7
 	k8s.io/api v0.25.6

--- a/go.sum
+++ b/go.sum
@@ -151,7 +151,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
-github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
 github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
 github.com/onsi/gomega v1.20.1/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/openconfig/kne v0.1.7 h1:+57nqk5vZziotgFo4pyslTWbcrWYGofOn4c+OAS8ueQ=

--- a/tests/integration/srlinux_controller_test.go
+++ b/tests/integration/srlinux_controller_test.go
@@ -1,145 +1,121 @@
-/*
-Copyright (c) 2021 Nokia. All rights reserved.
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
-package controllers
+package integration_controllers_test
 
 import (
-	"context"
 	"fmt"
-	"time"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	srlinuxv1 "github.com/srl-labs/srl-controller/api/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("Srlinux controller", func() {
-	// Define utility constants for object names and testing timeouts/durations and intervals.
-	const (
-		SrlinuxName      = "test-srlinux"
-		SrlinuxNamespace = "test"
-	)
+const (
+	SrlinuxNamespace = "test"
+	SrlinuxName      = "test-srlinux"
+	testImageName    = "srlinux:latest"
+)
 
-	Context("Srlinux controller test", func() {
-		ctx := context.Background()
+var namespacedName = types.NamespacedName{Name: SrlinuxName, Namespace: SrlinuxNamespace}
 
-		namespace := &corev1.Namespace{
+func TestSrlinuxReconciler(t *testing.T) {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: SrlinuxNamespace,
+		},
+	}
+
+	setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+		t.Helper()
+
+		t.Log("Creating the namespace")
+		g.Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
+
+		return namespace
+	}
+
+	teardown := func(t *testing.T, _ *WithT) {
+		t.Helper()
+
+		t.Log("Deleting the namespace")
+
+		_ = k8sClient.Delete(ctx, namespace)
+	}
+
+	t.Run("Should reconcile a Srlinux custom resource", func(t *testing.T) {
+		g := NewWithT(t)
+
+		setup(t, g)
+		defer teardown(t, g)
+
+		t.Log("Checking that Srlinux resource doesn't exist in the cluster")
+		srlinux := &srlinuxv1.Srlinux{}
+
+		err := k8sClient.Get(ctx, namespacedName, srlinux)
+
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		t.Log("Creating the custom resource for the Kind Srlinux")
+		srlinux = &srlinuxv1.Srlinux{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: SrlinuxNamespace,
+				Name:      SrlinuxName,
+				Namespace: SrlinuxNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Srlinux",
+				APIVersion: "kne.srlinux.dev/v1",
+			},
+			Spec: srlinuxv1.SrlinuxSpec{
+				Config: &srlinuxv1.NodeConfig{
+					Image: testImageName,
+				},
 			},
 		}
+		g.Expect(k8sClient.Create(ctx, srlinux)).Should(Succeed())
 
-		typeNamespaceName := types.NamespacedName{Name: SrlinuxName, Namespace: SrlinuxNamespace}
+		t.Log("Checking if the custom resource was successfully created")
+		g.Eventually(func() error {
+			found := &srlinuxv1.Srlinux{}
 
-		BeforeEach(func() {
-			By("Creating the Namespace to perform the tests")
-			Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
-		})
+			return k8sClient.Get(ctx, namespacedName, found)
+		}).Should(Succeed())
 
-		AfterEach(func() {
-			By("Deleting the Namespace to perform the tests")
-			_ = k8sClient.Delete(ctx, namespace)
-		})
+		// Reconcile is triggered by the creation of the custom resource
 
-		It("should successfully reconcile a custom resource for Srlinux created with just an image referenced", func() {
-			By("Checking that Srlinux resource doesn't exist in the cluster")
+		t.Log("Checking if Srlinux Pod was successfully created in the reconciliation")
+		g.Eventually(func() error {
+			found := &corev1.Pod{}
 
-			srlinux := &srlinuxv1.Srlinux{}
+			return k8sClient.Get(ctx, namespacedName, found)
+		}).Should(Succeed())
 
-			err := k8sClient.Get(ctx, typeNamespaceName, srlinux)
+		t.Log("Ensuring the Srlinux CR Status has been updated")
+		g.Eventually(func() error {
+			g.Expect(k8sClient.Get(ctx, namespacedName, srlinux)).Should(Succeed())
 
-			Expect(errors.IsNotFound(err)).To(BeTrue())
-
-			By("Creating the custom resource for the Kind Srlinux")
-			srlinux = &srlinuxv1.Srlinux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      SrlinuxName,
-					Namespace: SrlinuxNamespace,
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Srlinux",
-					APIVersion: "kne.srlinux.dev/v1",
-				},
-				Spec: srlinuxv1.SrlinuxSpec{
-					Config: &srlinuxv1.NodeConfig{
-						Image: "srlinux:latest",
-					},
-				},
+			if srlinux.Status.Image != testImageName {
+				return fmt.Errorf("got Srlinux.Status.Image: %s, want: %s", srlinux.Status.Image, testImageName)
 			}
-			Expect(k8sClient.Create(ctx, srlinux)).Should(Succeed())
 
-			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
-				found := &srlinuxv1.Srlinux{}
+			return nil
+		}).Should(Succeed())
 
-				return k8sClient.Get(ctx, typeNamespaceName, found)
-			}, 10*time.Second, time.Second).Should(Succeed())
+		t.Log("Deleting the custom resource for the Kind Srlinux")
+		g.Expect(k8sClient.Delete(ctx, srlinux)).Should(Succeed())
 
-			// Reconcile is triggered by the creation of the custom resource
+		t.Log("Checking if the custom resource was successfully deleted")
+		g.Eventually(func() error {
+			found := &srlinuxv1.Srlinux{}
 
-			By("Checking if Srlinux Pod was successfully created in the reconciliation")
-			Eventually(func() error {
-				found := &corev1.Pod{}
+			return k8sClient.Get(ctx, namespacedName, found)
+		}).ShouldNot(Succeed())
 
-				return k8sClient.Get(ctx, typeNamespaceName, found)
-			}, 10*time.Second, time.Second).Should(Succeed())
+		// because there are no controllers monitoring built-in resources in the envtest cluster,
+		// objects do not get deleted, even if an OwnerReference is set up
 
-			By("Ensuring the Srlinux CR Status has been updated")
-			Eventually(func() error {
-				Expect(k8sClient.Get(ctx, typeNamespaceName, srlinux)).Should(Succeed())
-
-				if srlinux.Status.Image != "srlinux:latest" {
-					return fmt.Errorf("got Srlinux.Status.Image: %s, want: %s", srlinux.Status.Image, "srlinux:latest")
-				}
-
-				return nil
-			}, 10*time.Second, time.Second).Should(Succeed())
-
-			By("Deleting the custom resource for the Kind Srlinux")
-			Expect(k8sClient.Delete(ctx, srlinux)).Should(Succeed())
-
-			By("Checking if the custom resource was successfully deleted")
-			Eventually(func() error {
-				found := &srlinuxv1.Srlinux{}
-
-				return k8sClient.Get(ctx, typeNamespaceName, found)
-			}, 10*time.Second, time.Second).ShouldNot(Succeed())
-
-			// because there are no controllers monitoring built-in resources in the envtest cluster,
-			// objects do not get deleted, even if an OwnerReference is set up
-
-			// Reconcile is triggered by the deletion of the custom resource
-		})
+		// Reconcile is triggered by the deletion of the custom resource
 	})
-})
+}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -1,21 +1,15 @@
 /*
 Copyright (c) 2021 Nokia. All rights reserved.
-
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its
    contributors may be used to endorse or promote products derived from
    this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,39 +22,35 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-package controllers
+package integration_controllers_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	srlinuxv1 "github.com/srl-labs/srl-controller/api/v1"
 	srlctrl "github.com/srl-labs/srl-controller/controllers"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	srlinuxv1 "github.com/srl-labs/srl-controller/api/v1"
-	//+kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
+	env        *envtest.Environment
+	ctx        context.Context
+	cancel     context.CancelFunc
+	fakeScheme = runtime.NewScheme()
+	k8sClient  client.Client
 )
 
 // prepareEnvTest sets up the environment vars used by envtest to create a test environment.
@@ -72,64 +62,81 @@ func prepareEnvTest() {
 		// Use the default location of the envtest binaries.
 		// note that the k8s version must match the version used in the Makefile.
 		assetstPath := filepath.Join("..", "..", "bin", "k8s", "1.25.0-linux-amd64")
-		Expect(os.Setenv("KUBEBUILDER_ASSETS", assetstPath)).To(Succeed())
+		os.Setenv("KUBEBUILDER_ASSETS", assetstPath)
 	}
 }
 
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Controller Suite")
-}
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	ctx, cancel = context.WithCancel(context.TODO())
-
+// TestMain is the entry point for the integration tests.
+// It sets up the envtest environment and starts the controller manager.
+func TestMain(m *testing.M) {
 	prepareEnvTest()
 
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	env = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+	SetDefaultEventuallyTimeout(10 * time.Second)
 
-	err = srlinuxv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	cfg, err := env.Start()
+	if err != nil {
+		panic(err)
+	}
 
-	//+kubebuilder:scaffold:scheme
+	// add k8s scheme
+	if err := clientgoscheme.AddToScheme(fakeScheme); err != nil {
+		panic(err)
+	}
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	// add srlinux scheme
+	if err := srlinuxv1.AddToScheme(fakeScheme); err != nil {
+		panic(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: fakeScheme})
+	if err != nil {
+		panic(err)
+	}
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme: fakeScheme,
 	})
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		panic(err)
+	}
 
 	err = (&srlctrl.SrlinuxReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		panic(err)
+	}
 
 	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-})
+		fmt.Println("Starting the test environment manager")
 
-var _ = AfterSuite(func() {
+		if err := k8sManager.Start(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+		}
+	}()
+	<-k8sManager.Elected()
+
+	rc := m.Run()
+
 	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})
+
+	fmt.Println("Tearing down the test environment")
+
+	err = env.Stop()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(rc)
+}


### PR DESCRIPTION
Refactoring integration tests to use `go test` instead of `ginkgo`.