### PR TITLE
chore: bump tag in kustomize bits to match latest release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To build `srl-controller` container image, execute:
 
 ```bash
 # don't forget to set the correct tag
-# for example make docker-build IMG=ghcr.io/srl-labs/srl-controller:v0.6.0
+# for example make docker-build IMG=ghcr.io/srl-labs/srl-controller:v0.6.1
 make docker-build IMG=ghcr.io/srl-labs/srl-controller:${tag}
 ```
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: ghcr.io/srl-labs/srl-controller
-    newTag: v0.6.0
+    newTag: v0.6.1


### PR DESCRIPTION
my bad, missed this, not used to kustomize things :D 