### PR TITLE
Enable SR Linux nodes to survive and recover from cold reboots

### DIFF
--- a/controllers/cfgmap_test.go
+++ b/controllers/cfgmap_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	srlinuxv1 "github.com/srl-labs/srl-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateConfigMaps(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	ns := "test-reboot-ns"
+
+	fakeClient := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
+	reconciler := &SrlinuxReconciler{
+		Client: fakeClient,
+		Scheme: clientgoscheme.Scheme,
+	}
+
+	srl := &srlinuxv1.Srlinux{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-srl",
+			Namespace: ns,
+		},
+		Spec: srlinuxv1.SrlinuxSpec{
+			Config: &srlinuxv1.NodeConfig{
+				Image: "ghcr.io/nokia/srlinux:latest",
+			},
+		},
+	}
+
+	// 1. First invocation creates all required ConfigMaps
+	err := createConfigMaps(ctx, reconciler, srl, logr.Discard())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// 2. Verify topomac script ConfigMap
+	topomacCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: topomacCfgMapName, Namespace: ns}, topomacCM)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(topomacCM.Data).To(HaveKey("topomac.sh"))
+	topomacScript := topomacCM.Data["topomac.sh"]
+	g.Expect(topomacScript).To(ContainSubstring("/etc/opt/srlinux/topology.yml"))
+	g.Expect(topomacScript).To(ContainSubstring("cp -f"))
+	g.Expect(topomacScript).To(ContainSubstring("__RANDMAC__"))
+
+	// 3. Verify kne-entrypoint ConfigMap
+	entrypointCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: entrypointCfgMapName, Namespace: ns}, entrypointCM)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(entrypointCM.Data).To(HaveKey("kne-entrypoint.sh"))
+	entrypointScript := entrypointCM.Data["kne-entrypoint.sh"]
+	g.Expect(entrypointScript).To(ContainSubstring("saved-mgmt-ip"))
+	g.Expect(entrypointScript).To(ContainSubstring("saved-mgmt-routes"))
+	g.Expect(entrypointScript).To(ContainSubstring("name eth0"))
+	g.Expect(entrypointScript).To(ContainSubstring("config.json"))
+
+	// 4. Verify variants ConfigMap
+	variantsCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: variantsCfgMapName, Namespace: ns}, variantsCM)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// 5. Test idempotency: subsequent calls succeed without error
+	err = createConfigMaps(ctx, reconciler, srl, logr.Discard())
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestVariantsManifests_DecodeCleanly(t *testing.T) {
+	manifests := []string{
+		"manifests/variants/topomac.yml",
+		"manifests/variants/kne-entrypoint.yml",
+		"manifests/variants/srl_variants.yml",
+	}
+
+	decoder := serializer.NewCodecFactory(clientgoscheme.Scheme).UniversalDecoder()
+
+	for _, m := range manifests {
+		t.Run(m, func(t *testing.T) {
+			g := NewWithT(t)
+
+			data, err := variantsFS.ReadFile(m)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to read embedded manifest %s", m)
+
+			cfgMap := &corev1.ConfigMap{}
+			err = runtime.DecodeInto(decoder, data, cfgMap)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to decode embedded manifest %s into ConfigMap", m)
+			g.Expect(cfgMap.Data).NotTo(BeEmpty(), "decoded ConfigMap data must not be empty")
+		})
+	}
+}

--- a/controllers/manifests/variants/kne-entrypoint.yml
+++ b/controllers/manifests/variants/kne-entrypoint.yml
@@ -11,12 +11,48 @@ metadata:
 data:
   kne-entrypoint.sh: |
     #!/bin/bash
-    # this entrypoint ensures that we call topomac script before executing the main entrypoint
+    # Entrypoint script executed on container start and restart.
 
     sudo bash /tmp/topomac/topomac.sh
-    echo "topomac.sh" script finished
+    echo "topomac.sh script finished"
 
-    # copy potentially provided startup config files
-    sudo cp -L /tmp/startup-config/* /etc/opt/srlinux/
+    # Manage management network interface across container restarts.
+    # On initial boot, eth0 exists with the CNI-assigned IP and routing table.
+    # Cache them to persistent storage (/etc/opt/srlinux).
+    if { [ ! -s /etc/opt/srlinux/saved-mgmt-ip ] || [ ! -s /etc/opt/srlinux/saved-mgmt-routes ]; } && ip link show eth0 >/dev/null 2>&1; then
+        echo "Caching management interface IP and routes from eth0..."
+        mgmt_ip=$(ip -4 -o addr show dev eth0 | awk '!/^[0-9]*: ?lo|link\/ether|link/ {print $4}' | head -n1)
+        if [ -n "$mgmt_ip" ]; then
+            echo "$mgmt_ip" | sudo tee /etc/opt/srlinux/saved-mgmt-ip >/dev/null
+        fi
+        sudo ip -4 route save dev eth0 | sudo tee /etc/opt/srlinux/saved-mgmt-routes >/dev/null
+    # On reboot, SR Linux previously renamed eth0 to mgmt0 and stripped its IP.
+    # Restore mgmt0 back to eth0 with its IP and routes so SR Linux initialization runs cleanly.
+    elif ip link show mgmt0 >/dev/null 2>&1 && ! ip link show eth0 >/dev/null 2>&1; then
+        echo "Restoring eth0 and management IP for container reboot..."
+        sudo ip link set mgmt0 down
+        sudo ip link set mgmt0 name eth0
+        sudo ip link set eth0 up
+        if [ -s /etc/opt/srlinux/saved-mgmt-ip ]; then
+            saved_ip=$(cat /etc/opt/srlinux/saved-mgmt-ip)
+            echo "Restoring IP $saved_ip to eth0"
+            sudo ip -4 addr add "$saved_ip" dev eth0 2>/dev/null || true
+        fi
+        if [ -s /etc/opt/srlinux/saved-mgmt-routes ]; then
+            echo "Restoring routes to eth0"
+            sudo ip -4 route restore < /etc/opt/srlinux/saved-mgmt-routes 2>/dev/null || true
+        fi
+    fi
+
+    # Only copy startup configuration on initial boot.
+    # On reboot, SR Linux boots directly from the persisted /etc/opt/srlinux/config.json.
+    if [ ! -f /etc/opt/srlinux/config.json ] && [ ! -f /etc/opt/srlinux/config.cli ]; then
+        if [ -d /tmp/startup-config ] && [ "$(ls -A /tmp/startup-config 2>/dev/null)" ]; then
+            echo "Seeding startup configuration into persistent volume..."
+            sudo cp -L /tmp/startup-config/* /etc/opt/srlinux/
+        fi
+    else
+        echo "Persistent configuration already exists in /etc/opt/srlinux, skipping seed."
+    fi
 
     exec /entrypoint.sh "$@"

--- a/controllers/manifests/variants/topomac.yml
+++ b/controllers/manifests/variants/topomac.yml
@@ -9,16 +9,25 @@ metadata:
 data:
   topomac.sh: |
     #!/bin/bash
-    # this script is used to generate random OUI for base mac entry of an SR Linux topology yaml file
+    # Generates or restores SR Linux topology definition with a consistent base MAC.
 
     template_path="/tmp/topo/topo-template.yml"
+    persistent_path="/etc/opt/srlinux/topology.yml"
+    tmp_path="/etc/opt/srlinux/topology.yml.tmp"
     final_path="/tmp/topology.yml"
 
-    # generate random bytes
-    b1=$(printf "%02X" $(shuf -i 0-255 -n1))
-    b2=$(printf "%02X" $(shuf -i 0-255 -n1))
-    mac_portion=$b1:$b2
+    if [ ! -s "$persistent_path" ]; then
+        echo "Generating new chassis base MAC on initial boot..."
+        b1=$(printf "%02X" $(shuf -i 0-255 -n1))
+        b2=$(printf "%02X" $(shuf -i 0-255 -n1))
+        mac_portion="${b1}:${b2}"
 
-    cp $template_path $final_path
+        sudo cp "$template_path" "$tmp_path"
+        sudo sed -i "s/__RANDMAC__/${mac_portion}/g" "$tmp_path"
+        sudo mv -f "$tmp_path" "$persistent_path"
+    else
+        echo "Reusing persistent chassis base MAC from previous boot."
+    fi
 
-    sed -i s/__RANDMAC__/$mac_portion/g $final_path
+    # Copy persistent topology definition to /tmp/topology.yml
+    sudo cp -f "$persistent_path" "$final_path"

--- a/controllers/pod.go
+++ b/controllers/pod.go
@@ -27,6 +27,9 @@ const (
 	readinessInitialDelay         = 10
 	readinessPeriodSeconds        = 5
 	readinessFailureThreshold     = 10
+
+	srlStateVolName = "srl-state"
+	srlStateMntPath = "/etc/opt/srlinux"
 )
 
 // podForSrlinux returns a srlinux Pod object.
@@ -144,6 +147,12 @@ func createAffinity(s *srlinuxv1.Srlinux) *corev1.Affinity {
 func createVolumes(s *srlinuxv1.Srlinux) []corev1.Volume {
 	vols := []corev1.Volume{
 		{
+			Name: srlStateVolName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: variantsVolName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -191,6 +200,10 @@ func createVolumes(s *srlinuxv1.Srlinux) []corev1.Volume {
 
 func createVolumeMounts(s *srlinuxv1.Srlinux) []corev1.VolumeMount {
 	vms := []corev1.VolumeMount{
+		{
+			Name:      srlStateVolName,
+			MountPath: srlStateMntPath,
+		},
 		{
 			Name:      variantsVolName,
 			MountPath: variantsVolMntPath,

--- a/controllers/pod_test.go
+++ b/controllers/pod_test.go
@@ -1,0 +1,148 @@
+// Copyright 2022 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	srlinuxv1 "github.com/srl-labs/srl-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestPodForSrlinux_RebootPersistence(t *testing.T) {
+	tests := []struct {
+		name              string
+		srl               *srlinuxv1.Srlinux
+		expectStartupVol  bool
+		expectedConfigDir string
+	}{
+		{
+			name: "without startup config",
+			srl: &srlinuxv1.Srlinux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-srl",
+					Namespace: "default",
+				},
+				Spec: srlinuxv1.SrlinuxSpec{
+					Config: &srlinuxv1.NodeConfig{
+						Image: "ghcr.io/nokia/srlinux:latest",
+					},
+				},
+			},
+			expectStartupVol: false,
+		},
+		{
+			name: "with default startup config path",
+			srl: &srlinuxv1.Srlinux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-srl-startup",
+					Namespace: "default",
+				},
+				Spec: srlinuxv1.SrlinuxSpec{
+					Config: &srlinuxv1.NodeConfig{
+						Image:             "ghcr.io/nokia/srlinux:latest",
+						ConfigDataPresent: true,
+					},
+				},
+			},
+			expectStartupVol:  true,
+			expectedConfigDir: "/tmp/startup-config",
+		},
+		{
+			name: "with custom startup config path",
+			srl: &srlinuxv1.Srlinux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-srl-custom",
+					Namespace: "default",
+				},
+				Spec: srlinuxv1.SrlinuxSpec{
+					Config: &srlinuxv1.NodeConfig{
+						Image:             "ghcr.io/nokia/srlinux:latest",
+						ConfigDataPresent: true,
+						ConfigPath:        "/custom/startup/path",
+					},
+				},
+			},
+			expectStartupVol:  true,
+			expectedConfigDir: "/custom/startup/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			reconciler := &SrlinuxReconciler{
+				Scheme: scheme.Scheme,
+			}
+
+			pod := reconciler.podForSrlinux(context.Background(), tt.srl)
+			g.Expect(pod).NotTo(BeNil())
+
+			// 1. Verify srl-state volume with EmptyDir is always present
+			var stateVol *corev1.Volume
+			for i := range pod.Spec.Volumes {
+				v := &pod.Spec.Volumes[i]
+				if v.Name == srlStateVolName {
+					stateVol = v
+					break
+				}
+			}
+			g.Expect(stateVol).NotTo(BeNil(), "expected srl-state volume to be present in pod.Spec.Volumes")
+			g.Expect(stateVol.EmptyDir).NotTo(BeNil(), "expected srl-state volume source to be EmptyDir")
+
+			// 2. Verify srl-state volume mount at /etc/opt/srlinux in container
+			g.Expect(pod.Spec.Containers).NotTo(BeEmpty())
+			var stateMount *corev1.VolumeMount
+			for i := range pod.Spec.Containers[0].VolumeMounts {
+				vm := &pod.Spec.Containers[0].VolumeMounts[i]
+				if vm.Name == srlStateVolName {
+					stateMount = vm
+					break
+				}
+			}
+			g.Expect(stateMount).NotTo(BeNil(), "expected srl-state volume mount to be present in container volume mounts")
+			g.Expect(stateMount.MountPath).To(Equal(srlStateMntPath))
+			g.Expect(stateMount.MountPath).To(Equal("/etc/opt/srlinux"))
+
+			// 3. Verify startup-config volume and mount interaction if expected
+			var startupVol *corev1.Volume
+			for i := range pod.Spec.Volumes {
+				v := &pod.Spec.Volumes[i]
+				if v.Name == "startup-config-volume" {
+					startupVol = v
+					break
+				}
+			}
+
+			var startupMount *corev1.VolumeMount
+			for i := range pod.Spec.Containers[0].VolumeMounts {
+				vm := &pod.Spec.Containers[0].VolumeMounts[i]
+				if vm.Name == "startup-config-volume" {
+					startupMount = vm
+					break
+				}
+			}
+
+			if tt.expectStartupVol {
+				g.Expect(startupVol).NotTo(BeNil(), "expected startup-config-volume in pod.Spec.Volumes")
+				g.Expect(startupVol.ConfigMap).NotTo(BeNil())
+				g.Expect(startupVol.ConfigMap.Name).To(Equal(tt.srl.Name + "-config"))
+
+				g.Expect(startupMount).NotTo(BeNil(), "expected startup-config-volume mount in container")
+				g.Expect(startupMount.MountPath).To(Equal(tt.expectedConfigDir))
+				// Ensure startup config does not overwrite or shadow the persistent srl-state mount path
+				g.Expect(startupMount.MountPath).NotTo(Equal(srlStateMntPath))
+			} else {
+				g.Expect(startupVol).To(BeNil(), "did not expect startup-config-volume")
+				g.Expect(startupMount).To(BeNil(), "did not expect startup-config-volume mount")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem
Triggering a container restart or gNOI cold reboot causes loss of management connectivity and state:

1. **Network Interface Destruction:** During boot, SR Linux moves `eth0` into child network namespace `srbase-mgmt` and renames it to `mgmt0`. When the container exits and restarts, Linux collapses the child namespace and returns `mgmt0` to the container netns in a down state with all CNI-assigned IP addresses and routes flushed. Subsequent startup scripts fail because `eth0` no longer exists.
2. **Base MAC Churn:** `topomac.sh` generated a random base MAC via `shuf` on every container start, changing the node chassis MAC address on each reboot.
3. **State Loss:** `/etc/opt/srlinux` was ephemeral to the container filesystem. Reboots wiped runtime state, certificates, and `config.json`, forcing the node to re-seed from initial configuration templates.

### Solution
- **`controllers/pod.go`:** Mounted an `emptyDir` volume (`srl-state`) at `/etc/opt/srlinux` to persist configuration, license, certificates, and runtime metadata across container restarts within the Pod lifecycle.
- **`controllers/manifests/variants/kne-entrypoint.yml`:**
  - On initial start, caches `eth0` IPv4 address and routing table to persistent storage (`/etc/opt/srlinux`).
  - On restart, detects leftover `mgmt0`, renames it to `eth0`, and re-applies the cached IP address and default routes prior to executing `/entrypoint.sh`.
  - Bypasses startup-config template seeding if `/etc/opt/srlinux/config.json` already exists.
- **`controllers/manifests/variants/topomac.yml`:**
  - Persists generated `topology.yml` in `/etc/opt/srlinux/topology.yml` using an atomic write (`.tmp` file and `mv -f`).
  - Reuses the existing file on restart to maintain chassis base MAC stability across reboots. Copies persistent file to `/tmp/topology.yml`.
- **Unit Tests:**
  - `controllers/pod_test.go`: Added unit tests verifying `srl-state` volume and volume mount generation.
  - `controllers/cfgmap_test.go`: Added assertions verifying entrypoint network recovery and topomac persistence logic.

### Verification

Created container in KNE environment.  After a gNOI reboot RPC, verified the interface macs remain the same and all network connectivity still works.